### PR TITLE
#5/#18: Thumbnails in video lists and OBS profiles

### DIFF
--- a/src/io/github/trdesilva/autorecorder/Settings.java
+++ b/src/io/github/trdesilva/autorecorder/Settings.java
@@ -61,6 +61,10 @@ public class Settings
         public boolean bookmarksEnabled = false;
         public Hotkey bookmarkKey = new Hotkey();
         public boolean consumeWindowsKeyEnabled = false;
+        
+        public String obsProfileName = "Untitled";
+        public boolean overrideObsNameFormat = false;
+        
     }
     
     private final EventQueue events;
@@ -273,6 +277,26 @@ public class Settings
     public void setConsumeWindowsKeyEnabled(boolean consumeWindowsKeyEnabled)
     {
         this.container.consumeWindowsKeyEnabled = consumeWindowsKeyEnabled;
+    }
+    
+    public String getObsProfileName()
+    {
+        return this.container.obsProfileName;
+    }
+    
+    public void setObsProfileName(String name)
+    {
+        this.container.obsProfileName = name;
+    }
+    
+    public boolean isOverrideObsNameFormatEnabled()
+    {
+        return this.container.overrideObsNameFormat;
+    }
+    
+    public void setOverrideObsNameFormatEnabled(boolean enable)
+    {
+        this.container.overrideObsNameFormat = enable;
     }
     
     public String getSettingsFilePath()

--- a/src/io/github/trdesilva/autorecorder/SettingsValidator.java
+++ b/src/io/github/trdesilva/autorecorder/SettingsValidator.java
@@ -10,6 +10,7 @@ import io.github.trdesilva.autorecorder.event.Event;
 import io.github.trdesilva.autorecorder.event.EventProperty;
 import io.github.trdesilva.autorecorder.event.EventQueue;
 import io.github.trdesilva.autorecorder.event.EventType;
+import io.github.trdesilva.autorecorder.record.Obs;
 import io.github.trdesilva.autorecorder.video.Hotkey;
 
 import java.io.File;
@@ -18,11 +19,13 @@ import java.util.Collections;
 public class SettingsValidator
 {
     private final EventQueue events;
+    private final Obs obs;
     
     @Inject
-    public SettingsValidator(EventQueue events)
+    public SettingsValidator(EventQueue events, Obs obs)
     {
         this.events = events;
+        this.obs = obs;
     }
     
     public boolean validate(Settings.SettingsContainer settings)
@@ -43,6 +46,22 @@ public class SettingsValidator
         if(!settings.obsPath.endsWith(".exe") || !obsFile.canExecute())
         {
             events.postEvent(new Event(EventType.WARNING, "OBS path doesn't point to an executable"));
+            return false;
+        }
+        
+        if(settings.obsProfileName.isBlank())
+        {
+            events.postEvent(new Event(EventType.WARNING,
+                                       "OBS profile name is unset in settings. Is OBS Studio installed?",
+                                       Collections.singletonMap(EventProperty.LINK, "https://obsproject.com/kb/profiles")));
+            return false;
+        }
+        
+        if(!obs.readProfileNames().contains(settings.obsProfileName))
+        {
+            events.postEvent(new Event(EventType.WARNING,
+                                       "Selected OBS profile does not exist in OBS profile directory",
+                                       Collections.singletonMap(EventProperty.LINK, "https://obsproject.com/forum/threads/where-are-profiles-saved.462/")));
             return false;
         }
         

--- a/src/io/github/trdesilva/autorecorder/record/Obs.java
+++ b/src/io/github/trdesilva/autorecorder/record/Obs.java
@@ -10,11 +10,19 @@ import io.github.trdesilva.autorecorder.Settings;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Obs
 {
+    public static final Path PROFILES_DIR = Paths.get(System.getenv("APPDATA")).resolve("obs-studio").resolve("basic").resolve("profiles");
+    public static final String PROFILE_CONFIG_FILENAME = "basic.ini";
+    
     Settings settings;
     
     AtomicBoolean recording;
@@ -36,7 +44,9 @@ public class Obs
             if(settings.getObsPath() != null && !settings.getObsPath().isBlank())
             {
                 String obsDir = Paths.get(settings.getObsPath()).getParent().toString();
-                String[] obsArgs = {settings.getObsPath(), "--startrecording", "--minimize-to-tray", "--disable-updater", "--disable-shutdown-check"};
+                String[] obsArgs = {settings.getObsPath(), "--startrecording", "--minimize-to-tray", "--disable-updater",
+                        "--disable-shutdown-check", "--profile", String.format("\"%s\"", settings.getObsProfileName())};
+                
                 process = Runtime.getRuntime().exec(obsArgs, null, new File(obsDir));
                 recording.set(true);
             }
@@ -55,5 +65,29 @@ public class Obs
             process.destroyForcibly();
             recording.set(false);
         }
+    }
+    
+    public List<String> readProfileNames()
+    {
+        File[] maybeProfileDirs = PROFILES_DIR.toFile().listFiles();
+        if(maybeProfileDirs != null)
+        {
+            List<String> result = new ArrayList<>(maybeProfileDirs.length);
+            for(File maybeDir: maybeProfileDirs)
+            {
+                if(maybeDir.canRead() && maybeDir.isDirectory())
+                {
+                    result.add(maybeDir.getName());
+                }
+            }
+            return result;
+        }
+        
+        return Collections.emptyList();
+    }
+    
+    public File getActiveProfileConfigFile()
+    {
+        return PROFILES_DIR.resolve(settings.getObsProfileName()).resolve(PROFILE_CONFIG_FILENAME).toFile();
     }
 }

--- a/src/io/github/trdesilva/autorecorder/ui/gui/VideoInfoPanel.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/VideoInfoPanel.java
@@ -5,9 +5,6 @@
 
 package io.github.trdesilva.autorecorder.ui.gui;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import io.github.trdesilva.autorecorder.event.Event;
 import io.github.trdesilva.autorecorder.event.EventConsumer;
 import io.github.trdesilva.autorecorder.event.EventProperty;
@@ -16,7 +13,6 @@ import io.github.trdesilva.autorecorder.event.EventType;
 import io.github.trdesilva.autorecorder.ui.gui.wrapper.DefaultPanel;
 import io.github.trdesilva.autorecorder.video.VideoMetadataHandler;
 
-import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import java.awt.Image;
@@ -25,7 +21,6 @@ import java.awt.event.ComponentEvent;
 import java.io.File;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 public abstract class VideoInfoPanel extends DefaultPanel implements EventConsumer
 {
@@ -34,7 +29,6 @@ public abstract class VideoInfoPanel extends DefaultPanel implements EventConsum
     
     protected final JLabel thumbnailLabel;
     protected final ImageIcon thumbnailImage;
-    protected final LoadingCache<String, Image> thumbnailCache;
     
     protected File currentVideo;
     
@@ -45,32 +39,6 @@ public abstract class VideoInfoPanel extends DefaultPanel implements EventConsum
     
         thumbnailLabel = new JLabel();
         thumbnailImage = new ImageIcon();
-        
-        thumbnailCache = CacheBuilder.newBuilder().maximumSize(100).build(new CacheLoader<String, Image>() {
-            @Override
-            public Image load(String key) throws Exception
-            {
-                if(!key.isBlank())
-                {
-                    eventQueue.postEvent(new Event(EventType.DEBUG, String.format("Loading thumbnail for %s from %s", currentVideo.getAbsolutePath(), key)));
-                    File thumbnailFile = new File(key);
-                    if(thumbnailFile.exists())
-                    {
-                        Image image = ImageIO.read(thumbnailFile);
-                    
-                        // image width is -1 while image is loading
-                        int loadingWaitCounter = 0;
-                        while(image.getWidth(null) == -1 && loadingWaitCounter++ < 10)
-                        {
-                            Thread.sleep(50);
-                        }
-                    
-                        return image;
-                    }
-                }
-                return null;
-            }
-        });
         
         addComponentListener(new ComponentAdapter() {
             @Override
@@ -107,31 +75,20 @@ public abstract class VideoInfoPanel extends DefaultPanel implements EventConsum
     
     private boolean setScaledThumbnail(File video)
     {
-        String thumbnailPath = metadataHandler.getMetadata(video).getThumbnailPath();
-        if(!thumbnailPath.isBlank() && new File(thumbnailPath).exists())
+        Image image = metadataHandler.getThumbnail(video);
+        if(image != null)
         {
-            try
-            {
-                Image image = thumbnailCache.get(thumbnailPath);
-                if(image != null)
-                {
-                    int imageWidth = (int)(Math.min(getWidth() * 0.9, 270));
-                    Image scaledImage = image.getScaledInstance(imageWidth, (int)(imageWidth*9./16), Image.SCALE_SMOOTH);
-                    thumbnailImage.setImage(scaledImage);
-                    thumbnailLabel.setIcon(thumbnailImage);
-                    thumbnailLabel.setText("");
-                    repaint();
-                    return true;
-                }
-                else
-                {
-                    eventQueue.postEvent(new Event(EventType.WARNING, "Could not load thumbnail for " + video.getName()));
-                }
-            }
-            catch(ExecutionException e)
-            {
-                eventQueue.postEvent(new Event(EventType.WARNING, "Could not load thumbnail for " + video.getName()));
-            }
+            int imageWidth = (int)(Math.min(getWidth() * 0.9, 270));
+            Image scaledImage = image.getScaledInstance(imageWidth, (int)(imageWidth*9./16), Image.SCALE_SMOOTH);
+            thumbnailImage.setImage(scaledImage);
+            thumbnailLabel.setIcon(thumbnailImage);
+            thumbnailLabel.setText("");
+            repaint();
+            return true;
+        }
+        else
+        {
+            eventQueue.postEvent(new Event(EventType.WARNING, "Could not load thumbnail for " + video.getName()));
         }
         
         return false;

--- a/src/io/github/trdesilva/autorecorder/ui/gui/VideoListPanel.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/VideoListPanel.java
@@ -6,24 +6,48 @@
 package io.github.trdesilva.autorecorder.ui.gui;
 
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AtomicLongMap;
+import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import io.github.trdesilva.autorecorder.event.Event;
 import io.github.trdesilva.autorecorder.event.EventConsumer;
 import io.github.trdesilva.autorecorder.event.EventQueue;
 import io.github.trdesilva.autorecorder.event.EventType;
+import io.github.trdesilva.autorecorder.ui.gui.wrapper.WrappingLabel;
 import io.github.trdesilva.autorecorder.video.VideoListHandler;
+import io.github.trdesilva.autorecorder.video.VideoMetadataHandler;
+import net.miginfocom.swing.MigLayout;
 
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.ImageIcon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JList;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,23 +59,34 @@ public class VideoListPanel extends JScrollPane implements EventConsumer
         DATE
     }
     
+    public enum DisplayType
+    {
+        NAMES,
+        TILES
+    }
+    
     private static final Set<EventType> EVENT_TYPES = Sets.immutableEnumSet(EventType.RECORDING_END);
     
     private final EventQueue events;
+    private final VideoListCellRenderer renderer;
     private VideoListHandler videoListHandler;
     
     private final JList<File> videos;
     private SortOrder sortOrder;
     
     @AssistedInject
-    public VideoListPanel(EventQueue events, @Assisted VideoListHandler videoListHandler, @Assisted VideoInfoPanel selectionConsumer)
+    public VideoListPanel(EventQueue events, VideoListCellRenderer renderer, @Assisted VideoListHandler videoListHandler, @Assisted VideoInfoPanel selectionConsumer)
     {
         this.events = events;
+        this.renderer = renderer;
         
-        // TODO custom renderer with thumbnails
         this.videoListHandler = videoListHandler;
         videos = new JList<>(videoListHandler.getVideoList().toArray(new File[0]));
         videos.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        this.renderer.setParent(this);
+        videos.setCellRenderer(renderer);
+        videos.setLayoutOrientation(JList.HORIZONTAL_WRAP);
+        videos.setVisibleRowCount(-1);
         
         sortOrder = SortOrder.DATE;
         
@@ -69,6 +104,24 @@ public class VideoListPanel extends JScrollPane implements EventConsumer
         });
         getViewport().add(videos);
         setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        setHorizontalScrollBarPolicy(HORIZONTAL_SCROLLBAR_NEVER);
+        
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e)
+            {
+                if(videos.getCellRenderer().equals(renderer))
+                {
+                    resetListCellSizes();
+                }
+                else
+                {
+                    videos.setFixedCellWidth(-1);
+                    videos.setFixedCellHeight(-1);
+                    videos.setVisibleRowCount(256);
+                }
+            }
+        });
         
         events.addConsumer(this);
     }
@@ -83,7 +136,7 @@ public class VideoListPanel extends JScrollPane implements EventConsumer
             {
                 case NAME:
                     videoList = videoList.stream()
-                                         .sorted(Comparator.comparing(File::getName))
+                                         .sorted(Comparator.comparing((file) -> file.getName().toLowerCase()))
                                          .collect(Collectors.toList());
                     break;
                 case DATE:
@@ -95,6 +148,37 @@ public class VideoListPanel extends JScrollPane implements EventConsumer
         }
         File[] videoArray = videoList.toArray(new File[0]);
         videos.setListData(videoArray);
+    }
+    
+    public void changeDisplayType(DisplayType type)
+    {
+        if(type == DisplayType.TILES)
+        {
+            videos.setCellRenderer(renderer);
+            videos.setLayoutOrientation(JList.HORIZONTAL_WRAP);
+            resetListCellSizes();
+        }
+        else
+        {
+            videos.setCellRenderer(new DefaultListCellRenderer());
+            videos.setLayoutOrientation(JList.VERTICAL);
+            videos.setFixedCellWidth(-1);
+            videos.setFixedCellHeight(-1);
+            videos.setVisibleRowCount(256);
+        }
+    }
+    
+    private void resetListCellSizes()
+    {
+        int oldCellWidth = videos.getFixedCellWidth();
+        int newCellWidth = (int) (Math.min(340, getWidth() / 4. - 5));
+        if(oldCellWidth != newCellWidth)
+        {
+            videos.setFixedCellWidth(newCellWidth);
+            videos.setFixedCellHeight(30 + videos.getFixedCellWidth() * 9 / 16);
+            videos.setVisibleRowCount(videos.getModel().getSize() / (getWidth() / newCellWidth) + 1);
+            renderer.clearCaches();
+        }
     }
     
     @Override
@@ -110,5 +194,128 @@ public class VideoListPanel extends JScrollPane implements EventConsumer
     public Set<EventType> getSubscriptions()
     {
         return EVENT_TYPES;
+    }
+    
+    private static class VideoListCellRenderer implements ListCellRenderer<File>
+    {
+        private final VideoMetadataHandler metadataHandler;
+        private final AtomicLongMap<File> renderStatusMap;
+        private final AtomicLongMap<File> loadAttempts;
+        private final Map<File, JComponent> resultCache;
+        private JComponent parent;
+        
+        @Inject
+        public VideoListCellRenderer(VideoMetadataHandler metadataHandler)
+        {
+            this.metadataHandler = metadataHandler;
+            renderStatusMap = AtomicLongMap.create();
+            loadAttempts = AtomicLongMap.create();
+            resultCache = new HashMap<>();
+        }
+        
+        @Override
+        public Component getListCellRendererComponent(JList<? extends File> list, File value, int index,
+                                                      boolean isSelected, boolean cellHasFocus)
+        {
+            JComponent result;
+            synchronized(value)
+            {
+                if(renderStatusMap.get(value) == 2)
+                {
+                    result = resultCache.get(value);
+                }
+                else
+                {
+                    result = new JPanel();
+                    JLabel thumbnailLabel = new JLabel();
+                    WrappingLabel titleLabel = new WrappingLabel(value.getName());
+                    int extIndex = value.getName().indexOf('.');
+                    if(extIndex != -1)
+                    {
+                        titleLabel.setText(value.getName().substring(0, extIndex));
+                    }
+                    GridBagLayout layout = new GridBagLayout();
+                    
+                    result.setLayout(layout);
+    
+                    int imageWidth = list.getFixedCellWidth() - 10;
+                    Image image = null;
+                    if(renderStatusMap.get(value) == 0)
+                    {
+                        image = metadataHandler.getThumbnail(value, false);
+                    }
+    
+                    if(image != null)
+                    {
+                        Image scaledImage = image.getScaledInstance(imageWidth, (int) (imageWidth * 9. / 16),
+                                                                    Image.SCALE_SMOOTH);
+                        thumbnailLabel.setIcon(new ImageIcon(scaledImage));
+                        thumbnailLabel.setText("");
+                        renderStatusMap.put(value, 2);
+                    }
+                    else
+                    {
+                        thumbnailLabel.setText("Loading...");
+                        if(renderStatusMap.get(value) == 0 && loadAttempts.getAndIncrement(value) < 5)
+                        {
+                            renderStatusMap.put(value, 1);
+                            SwingUtilities.invokeLater(() -> {
+                                metadataHandler.getThumbnail(value, true);
+                                if(renderStatusMap.get(value) == 1)
+                                {
+                                    renderStatusMap.put(value, 0);
+                                }
+                                list.repaint();
+                            });
+                        }
+                    }
+    
+                    result.add(thumbnailLabel);
+                    result.add(titleLabel);
+                    
+                    GridBagConstraints thumbnailConstraints = new GridBagConstraints();
+                    thumbnailConstraints.fill = GridBagConstraints.NONE;
+                    thumbnailConstraints.anchor = GridBagConstraints.CENTER;
+                    thumbnailConstraints.gridy = 1;
+                    layout.setConstraints(thumbnailLabel, thumbnailConstraints);
+    
+                    GridBagConstraints titleConstraints = new GridBagConstraints();
+                    titleConstraints.fill = GridBagConstraints.BOTH;
+                    titleConstraints.anchor = GridBagConstraints.CENTER;
+                    titleConstraints.gridy = 2;
+                    layout.setConstraints(titleLabel, titleConstraints);
+                    
+                    GridBagConstraints panelConstraints = new GridBagConstraints();
+                    panelConstraints.fill = GridBagConstraints.BOTH;
+                    panelConstraints.insets = new Insets(5, 5, 5, 5);
+                    layout.setConstraints(result, panelConstraints);
+    
+                    resultCache.put(value, result);
+                }
+            }
+    
+            if(isSelected)
+            {
+                result.setBackground(UIManager.getColor("List.selectionBackground"));
+            }
+            else
+            {
+                result.setBackground(UIManager.getColor("List.background"));
+            }
+            
+            return result;
+        }
+        
+        public void setParent(JComponent parent)
+        {
+            this.parent = parent;
+        }
+        
+        public void clearCaches()
+        {
+            renderStatusMap.clear();
+            loadAttempts.clear();
+            resultCache.clear();
+        }
     }
 }

--- a/src/io/github/trdesilva/autorecorder/ui/gui/clip/ClipListPanel.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/clip/ClipListPanel.java
@@ -24,12 +24,15 @@ public class ClipListPanel extends DefaultPanel
     private final VideoListPanel videoListPanel;
     private final JRadioButton dateSortButton;
     private final JRadioButton nameSortButton;
+    private final JRadioButton tileDisplayButton;
+    private final JRadioButton nameDisplayButton;
     
     @Inject
     public ClipListPanel(ClipInfoPanel clipInfoPanel, VideoListPanelFactory videoListPanelFactory,
                          @Named("CLIP") VideoListHandler clipListHandler)
     {
-        setLayout(new MigLayout("fill, insets 2", "[75%:75%:90%]2[10%:25%:300]", "[][grow]"));
+        MigLayout layout = new MigLayout("fill, insets 2", "[75%:75%:90%]2[10%::300]", "[30][300:100%]");
+        setLayout(layout);
         
         this.clipInfoPanel = clipInfoPanel;
         videoListPanel = videoListPanelFactory.create(clipListHandler, clipInfoPanel);
@@ -47,12 +50,29 @@ public class ClipListPanel extends DefaultPanel
         sortPanel.add(dateSortButton);
         sortPanel.add(nameSortButton);
         
-        add(sortPanel, "cell 0 0, left");
+        JPanel displayTypePanel = new JPanel();
+        displayTypePanel.setLayout(new MigLayout());
+        JLabel displayTypeLabel = new JLabel("Display as:");
+        ButtonGroup displayTypeButtons = new ButtonGroup();
+        tileDisplayButton = new JRadioButton("Tiles", true);
+        nameDisplayButton = new JRadioButton("Filenames");
+        displayTypeButtons.add(tileDisplayButton);
+        displayTypeButtons.add(nameDisplayButton);
+    
+        displayTypePanel.add(displayTypeLabel);
+        displayTypePanel.add(tileDisplayButton);
+        displayTypePanel.add(nameDisplayButton);
+    
+        add(sortPanel, "cell 0 0, left, growx, split 2");
+        add(displayTypePanel, "cell 0 0, growx, right");
         add(videoListPanel, "cell 0 1, grow");
         add(clipInfoPanel, "cell 1 0, grow, span 1 2");
     
         dateSortButton.addActionListener(e -> update(false));
         nameSortButton.addActionListener(e -> update(false));
+    
+        tileDisplayButton.addActionListener(e -> videoListPanel.changeDisplayType(VideoListPanel.DisplayType.TILES));
+        nameDisplayButton.addActionListener(e -> videoListPanel.changeDisplayType(VideoListPanel.DisplayType.NAMES));
         
         update(false);
     }

--- a/src/io/github/trdesilva/autorecorder/ui/gui/record/RecordingListPanel.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/record/RecordingListPanel.java
@@ -24,12 +24,15 @@ public class RecordingListPanel extends DefaultPanel
     private final VideoListPanel videoListPanel;
     private final JRadioButton dateSortButton;
     private final JRadioButton nameSortButton;
+    private final JRadioButton tileDisplayButton;
+    private final JRadioButton nameDisplayButton;
     
     @Inject
     public RecordingListPanel(RecordingInfoPanel recordingInfoPanel, VideoListPanelFactory videoListPanelFactory,
                               @Named("RECORDING") VideoListHandler recordingListHandler)
     {
-        setLayout(new MigLayout("fill, insets 2", "[75%:75%:90%]2[10%::300]", "[][grow]"));
+        MigLayout layout = new MigLayout("fill, insets 2", "[75%:75%:90%]2[10%::300]", "[30][300:100%]");
+        setLayout(layout);
     
         this.recordingInfoPanel = recordingInfoPanel;
         videoListPanel = videoListPanelFactory.create(recordingListHandler, recordingInfoPanel);
@@ -47,12 +50,29 @@ public class RecordingListPanel extends DefaultPanel
         sortPanel.add(dateSortButton);
         sortPanel.add(nameSortButton);
     
-        add(sortPanel, "cell 0 0, left");
-        add(videoListPanel, "cell 0 1, grow");
+        JPanel displayTypePanel = new JPanel();
+        displayTypePanel.setLayout(new MigLayout());
+        JLabel displayTypeLabel = new JLabel("Display as:");
+        ButtonGroup displayTypeButtons = new ButtonGroup();
+        tileDisplayButton = new JRadioButton("Tiles", true);
+        nameDisplayButton = new JRadioButton("Filenames");
+        displayTypeButtons.add(tileDisplayButton);
+        displayTypeButtons.add(nameDisplayButton);
+    
+        displayTypePanel.add(displayTypeLabel);
+        displayTypePanel.add(tileDisplayButton);
+        displayTypePanel.add(nameDisplayButton);
+    
+        add(sortPanel, "cell 0 0, left, growx, split 2");
+        add(displayTypePanel, "cell 0 0, growx, right");
+        add(videoListPanel, "cell 0 1, growx");
         add(recordingInfoPanel, "cell 1 0, grow, span 1 2");
         
         dateSortButton.addActionListener(e -> update(false));
         nameSortButton.addActionListener(e -> update(false));
+        
+        tileDisplayButton.addActionListener(e -> videoListPanel.changeDisplayType(VideoListPanel.DisplayType.TILES));
+        nameDisplayButton.addActionListener(e -> videoListPanel.changeDisplayType(VideoListPanel.DisplayType.NAMES));
         
         update(false);
     }

--- a/src/io/github/trdesilva/autorecorder/ui/gui/wrapper/ThumbnailCache.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/wrapper/ThumbnailCache.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025 Thomas DeSilva.
+ * Distributed under GPLv3.
+ */
+
+package io.github.trdesilva.autorecorder.ui.gui.wrapper;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.github.trdesilva.autorecorder.event.Event;
+import io.github.trdesilva.autorecorder.event.EventQueue;
+import io.github.trdesilva.autorecorder.event.EventType;
+
+import javax.annotation.CheckForNull;
+import javax.imageio.ImageIO;
+import java.awt.Image;
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+
+@Singleton
+public class ThumbnailCache implements LoadingCache<String, Image>
+{
+    private LoadingCache<String, Image> impl;
+    
+    @Inject
+    public ThumbnailCache(EventQueue eventQueue)
+    {
+        impl = CacheBuilder.newBuilder().maximumSize(100).build(new CacheLoader<String, Image>() {
+            @Override
+            public Image load(String key) throws Exception
+            {
+                if(!key.isBlank())
+                {
+                    eventQueue.postEvent(new Event(EventType.DEBUG, String.format("Loading thumbnail from %s", key)));
+                    File thumbnailFile = new File(key);
+                    if(thumbnailFile.exists())
+                    {
+                        Image image = ImageIO.read(thumbnailFile);
+                    
+                        // image width is -1 while image is loading
+                        int loadingWaitCounter = 0;
+                        while(image.getWidth(null) == -1 && loadingWaitCounter++ < 10)
+                        {
+                            Thread.sleep(50);
+                        }
+                    
+                        return image;
+                    }
+                }
+                return null;
+            }
+        });
+    }
+    
+    @Override
+    public Image get(String key) throws ExecutionException
+    {
+        return impl.get(key);
+    }
+    
+    @Override
+    public Image getUnchecked(String key)
+    {
+        return impl.getUnchecked(key);
+    }
+    
+    @Override
+    public ImmutableMap<String, Image> getAll(Iterable<? extends String> keys) throws ExecutionException
+    {
+        return impl.getAll(keys);
+    }
+    
+    @Override
+    public Image apply(String key)
+    {
+        return impl.apply(key);
+    }
+    
+    @Override
+    public void refresh(String key)
+    {
+        impl.refresh(key);
+    }
+    
+    @CheckForNull
+    @Override
+    public Image getIfPresent(Object key)
+    {
+        return impl.getIfPresent(key);
+    }
+    
+    @Override
+    public Image get(String key, Callable<? extends Image> loader) throws ExecutionException
+    {
+        return impl.get(key, loader);
+    }
+    
+    @Override
+    public ImmutableMap<String, Image> getAllPresent(Iterable<?> keys)
+    {
+        return impl.getAllPresent(keys);
+    }
+    
+    @Override
+    public void put(String key, Image value)
+    {
+        impl.put(key, value);
+    }
+    
+    @Override
+    public void putAll(Map<? extends String, ? extends Image> m)
+    {
+        impl.putAll(m);
+    }
+    
+    @Override
+    public void invalidate(Object key)
+    {
+        impl.invalidate(key);
+    }
+    
+    @Override
+    public void invalidateAll(Iterable<?> keys)
+    {
+        impl.invalidateAll(keys);
+    }
+    
+    @Override
+    public void invalidateAll()
+    {
+        impl.invalidateAll();
+    }
+    
+    @Override
+    public long size()
+    {
+        return impl.size();
+    }
+    
+    @Override
+    public CacheStats stats()
+    {
+        return impl.stats();
+    }
+    
+    @Override
+    public ConcurrentMap<String, Image> asMap()
+    {
+        return impl.asMap();
+    }
+    
+    @Override
+    public void cleanUp()
+    {
+        impl.cleanUp();
+    }
+}

--- a/src/io/github/trdesilva/autorecorder/ui/gui/wrapper/WrappingLabel.java
+++ b/src/io/github/trdesilva/autorecorder/ui/gui/wrapper/WrappingLabel.java
@@ -7,12 +7,27 @@ package io.github.trdesilva.autorecorder.ui.gui.wrapper;
 
 import javax.swing.JTextArea;
 import javax.swing.UIManager;
+import java.awt.Dimension;
 
 public class WrappingLabel extends JTextArea
 {
     public WrappingLabel(String text)
     {
         super(text);
+        setText(text);
+        setWrapStyleWord(true);
+        setLineWrap(true);
+        setOpaque(false);
+        setEditable(false);
+        setFocusable(false);
+        setBackground(UIManager.getColor("Label.background"));
+        setFont(UIManager.getFont("Label.font"));
+        setBorder(UIManager.getBorder("Label.border"));
+    }
+    
+    public WrappingLabel(String text, int maxX, int maxY)
+    {
+        super(text, maxX, maxY);
         setText(text);
         setWrapStyleWord(true);
         setLineWrap(true);

--- a/src/io/github/trdesilva/autorecorder/video/VideoListHandler.java
+++ b/src/io/github/trdesilva/autorecorder/video/VideoListHandler.java
@@ -132,7 +132,7 @@ public class VideoListHandler implements EventConsumer
             events.postEvent(new Event(EventType.DEBUG, "Starting autodelete check"));
             // sort videos oldest to newest (in deletion order)
             List<File> videoList = getVideoList().stream()
-                                                 .sorted((f1, f2) -> (int) (f1.lastModified() - f2.lastModified()))
+                    .sorted(Comparator.comparing(File::lastModified))
                                                  .collect(Collectors.toList());
             // don't automatically delete if there's only one video because that might be the active recording
             if(videoList.size() < 2)


### PR DESCRIPTION
The recording and clip lists can now use either Tile view or Filename view, where Tile view shows thumbnails and titles, and Filename view shows filepaths (same as current functionality). Also added options for choosing an OBS profile and changing recording names to match the recorded game.

I refactored thumbnail handling to be in the VideoMetadataHandler instead of the VideoInfoPanel since multiple things need to have thumbnails now. Also ran into a weird bug with MigLayout where it would cause a stack overflow if I tried to use it for the ListCellRenderer with a WrappingLabel (JTextArea), so had to use a GridBagLayout there instead.